### PR TITLE
Simplify Logo Handling

### DIFF
--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -21,7 +21,9 @@
 \author[Short Author]{Long Author} % short author title is used for the slide footer but optional
 \date{\today} % use a particular date here if needed
 
-\fancylogos{example-image-a,example-image-b,example-image-c} % define logos that are spread across the bottom of the title slide
+\fancylogos{example-image-a,example-image-b,example-image-c} % define logos that are spread evenly across the bottom of the title slide
+% \fancylogos{example-image-a} % just one logo is possible as well, e.g., the logo of your university
+% \fancylogos{,example-image-a} % you can use empty entries for a more fine-tuned alignment
 
 \begin{document}
 
@@ -169,7 +171,7 @@
 	\end{mycolumns}
 	\begin{note}{Explanation}
 		Using \texttt{\textbackslash picDark} instead of \texttt{\textbackslash pic}, the dark version of an image that is saved as \texttt{<image-name>-dark} automatically gets used when dark-mode is enabled.
-		
+
 		Images can also automatically be inverted if there is no separate dark version. Therefore, white gets converted to a dark gray that matches the dark background color of the slides.
 	\end{note}
 \end{frame}

--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -111,24 +111,21 @@
 % ---------------------------------------------
 % frame layout
 % ---------------------------------------------
-% [options for includegraphics]{logoname}
-\newcommand*\institutelogo[2][]{\def\@institutelogo{\includegraphics[height=4.5ex,#1]{#2}}}
-\newcommand*\clearinstitutelogo{\def\@institutelogo{}}
-\newcommand*\universitylogo[2][]{\def\@universitylogo{\includegraphics[height=4.5ex,#1]{#2}}}
-\newcommand*\clearuniversitylogo{\def\@universitylogo{}}
-\def\@mainlogo{\@institutelogo\hskip0pt plus 1filll\relax\@universitylogo}
+
+% we use this flag as a helper to toggle extra behavior when constructing the logos
 \newif\iffancy@logos@first@
-\newcommand*\fancylogos[2][]{\def\@mainlogo{%
+
+% [options for includegraphics, shared for all figures]{logonameA, logonameB, ...}
+\newcommand*\fancylogos[2][]{\def\fancy@logoline{%
     \fancy@logos@first@true
+    % we iterate over all images given in the comma-separated list
     \@for\@image:={#2}\do{%
-        \iffancy@logos@first@\fancy@logos@first@false\else \hskip0pt plus 1filll\fi
+        \iffancy@logos@first@\fancy@logos@first@false\else\hskip0pt plus 1filll\fi
         \ifthenelse{\equal{\@image}{}}{}{%
             \includegraphics[height=4.5ex,#1]{\@image}%
         }%
     }%
 }}
-\clearuniversitylogo
-\clearinstitutelogo
 
 \newcommand{\@createtitleslide}{
     {
@@ -150,7 +147,7 @@
         \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,left]{logobox}
             \vspace{-1ex}%
             \hspace{10pt}
-            \@mainlogo
+            \fancy@logoline
             \hspace{10pt}
         \end{beamercolorbox}%
     \end{frame}


### PR DESCRIPTION
This drops `\institutelogo`, `\clearinstitutelogo`, `\universitylogo`, and `\clearuniversitylogo`.

I was unsure how you wanted to proceed with the `release` branch in this repository. So for now (with no other changes staged for "initial" release), i use `main` as base. Feel free to change this!