### PR TITLE
Visually Balance Logos on Titlepage

### DIFF
--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -130,6 +130,7 @@
     }%
 }}
 
+\def\fancy@titlepage@margin{20pt}
 \newcommand{\@createtitleslide}{
     {
     \ifx \fancytitlepicture \empty \else \usebackgroundtemplate{\pic[trim=0 0 0 \fancytitlepictureoffset,clip,width=\paperwidth]{\fancytitlepicture}} \fi
@@ -139,15 +140,14 @@
             \LARGE\textbf{\inserttitle}\hspace*{20pt}
         \end{beamercolorbox}%
         \nointerlineskip%
-        \begin{beamercolorbox}[wd=\paperwidth,ht=2.25ex,dp=1ex,right]{subtitlebox}
+        \begin{beamercolorbox}[wd=\paperwidth,ht=2.25ex,dp=1ex,right,rightskip=\fancy@titlepage@margin]{subtitlebox}
             \small
             \ifx \insertsubtitle \empty \else \insertsubtitle\ $\vert$ \fi
             \insertauthor\
             \ifx \insertdate \empty \else $\vert$ \insertdate \fi
-            \hspace*{20pt}
         \end{beamercolorbox}%
         \nointerlineskip
-        \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,leftskip=10pt,rightskip=10pt]{logobox}
+        \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,leftskip=\fancy@titlepage@margin,rightskip=\fancy@titlepage@margin]{logobox}
             \vspace{-1ex}%
             \fancy@logoline
         \end{beamercolorbox}%

--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -147,11 +147,9 @@
             \hspace*{20pt}
         \end{beamercolorbox}%
         \nointerlineskip
-        \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,left]{logobox}
+        \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,leftskip=10pt,rightskip=10pt]{logobox}
             \vspace{-1ex}%
-            \hspace{10pt}
             \fancy@logoline
-            \hspace{10pt}
         \end{beamercolorbox}%
     \end{frame}
     }


### PR DESCRIPTION
Provides uniform logo spacing (left- and rightskip).
Furthermore this aligns the logo with the title.

![Screenshot_20240311_170651](https://github.com/SEatUPB/FancyBeamer/assets/9303573/09a32b28-6b58-4c6f-bffb-ddfde69a6b0a)

If you are not happy with the current alignment proposal, it can be changed easily by modifying the [`leftskip` and `rightskip` values](https://github.com/SEatUPB/FancyBeamer/compare/7-visually-balance-logos-on-titlepage?expand=1#diff-0904b9e4c150bf4252e7d3ca1fb17825541050877020fb048a18a9b20295a41cR150).