### PR TITLE
Fix maketitle error when no logos are defined

### DIFF
--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -119,6 +119,7 @@
 \newif\iffancy@logos@first@
 
 % [options for includegraphics, shared for all figures]{logonameA, logonameB, ...}
+\def\fancy@logoline{}
 \newcommand*\fancylogos[2][]{\def\fancy@logoline{%
     \fancy@logos@first@true
     % we iterate over all images given in the comma-separated list


### PR DESCRIPTION
I added a default (empty) definition of `\fancy@logoline` to prevent an error when using the `\maketitle` command without logos being defined via `\fancylogos`. This resolves #12.