### PR TITLE
Transparency on Titlepage

### DIFF
--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -23,12 +23,14 @@
 \newif\ifsectiontitleslide % for enabling the automatic section title slide at the begin of each section
 \newif\ifsectionoverview % for enabling the automatic section overview on the section title slide
 \newif\ifdarkmode
+\newif\iftransparenttitle % for enabling the transparency of the footer on the title slide
 
 \DeclareOption{nosectionframes}{\sectiontitleslidefalse \sectionoverviewfalse}
 \DeclareOption{sectiontitleslides}{\sectiontitleslidetrue \sectionoverviewfalse}
 \DeclareOption{sectionoverviews}{\sectiontitleslidetrue \sectionoverviewtrue}
 \DeclareOption{uniqueslidenumber}{\uniqueslidenumbersuffixtrue}
 \DeclareOption{darkmode}{\darkmodetrue}
+\DeclareOption{transparenttitle}{\transparenttitletrue}
 
 \ExecuteOptions{sectiontitleslides} % use sectiontitleslides as default
 \mode<handout>{\ExecuteOptions{sectionoverviews}} % use sectionoverviews as default in handout mode
@@ -150,6 +152,7 @@
             \ifx \insertdate \empty \else \insertdate \fi
         \end{beamercolorbox}%
         \nointerlineskip
+        \iftransparenttitle\pgfsetfillopacity{0.72}\fi
         \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,leftskip=\fancy@titlepage@margin,rightskip=\fancy@titlepage@margin]{logobox}
             \vspace{-1ex}%
             \fancy@logoline


### PR DESCRIPTION
As requested, i have added a toggle to allow for transparency on the titlepage (although it is rather hard to see with the sample picture):

![Screenshot_20240404_184313](https://github.com/SEatUPB/FancyBeamer/assets/9303573/9f933c53-0314-49a0-a02e-dbc61e4bf0c8)

Currently, the toggle is rather simple: a documentclass option `transparenttitle`. So, to open the discussion:

* do you want the transparency itself to be configurable? (currently it is fixed to `0.72`, which i quite like). 
* what name should the option/macro to enable the transparency have? something like `\settitlefootertransparency{.5}` feels... long