### PR TITLE
feat!: rename note box to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ The following colored boxes can be used for writing definitions, examples and no
    <Content>
 \end{example}
 
-\begin{note}{<Title>}
+\begin{info}{<Title>}
    <Content>
-\end{note}
+\end{info}
 ```
 
 #### Custom Color Boxes
@@ -212,11 +212,11 @@ You can also directly add a prefix and suffix to the box title at creation using
 
 #### Old Macros for Boxes
 
-Please note that, all of the macros in this section are deprecated (for not being verbatim-safe). Please use the `definition`, `example` and `note` environments described above. Yet, they are still created for backwards compatibility:
+Please note that, all of the macros in this section are deprecated (for not being verbatim-safe). Please use the `definition`, `example` and `info` environments described above. Yet, they are still created for backwards compatibility:
 
 - `\mydefinition{<title>}{<content>}`
 - `\myexample{<title>}{<content>}`
-- `\mynote{<title>}{<content>}`
+- `\myinfo{<title>}{<content>}`
 
 ### Dark Mode
 

--- a/demo-slides/demo-slides.tex
+++ b/demo-slides/demo-slides.tex
@@ -80,9 +80,9 @@
 			This is an example.
 		\end{example}
 	\nextcolumn
-		\begin{note}{A {\color{red} Note}}
-			This is a note.
-		\end{note}
+		\begin{info}{An {\color{red} Info-Box}}
+			This is a info.
+		\end{info}
 	\end{fancycolumns}
 	\vfill
 	Versions without captions:
@@ -95,9 +95,9 @@
 			This is an {\color{blue} example}.
 		\end{example}
 	\nextcolumn
-		\begin{note}{}
-			This is a {\color{red} note}.
-		\end{note}
+		\begin{info}{}
+			This is an {\color{red} info-box}.
+		\end{info}
 	\end{fancycolumns}
 	\vfill
 	Tight versions with white background (e.g., for use with pictures):
@@ -110,9 +110,9 @@
 			\centering\includegraphics[width=.75\linewidth]{example-image}
 		\end{exampletight}
 	\nextcolumn
-		\begin{notetight}{A Note}
+		\begin{infotight}{An Info-Box}
 			\centering\includegraphics[width=.75\linewidth]{example-image}
-		\end{notetight}
+		\end{infotight}
 	\end{fancycolumns}
 \end{frame}
 
@@ -157,37 +157,37 @@
 		\begin{example}{\texttt{\textbackslash pic} command}
 			\centering\pic[width=0.5\textwidth,trim={.2\width} {.2\height} {.2\width} {.2\height},clip]{example-image}
 		\end{example}
-		\begin{note}{Explanation}
+		\begin{info}{Explanation}
 			Using the command \texttt{\textbackslash pic\{filename\}} a picture can be included. It works like \texttt{\textbackslash adjincludegraphics} and therefore supports advanced options like \texttt{trim}.
-		\end{note}
+		\end{info}
 	\nextcolumn
 		\begin{example}{Automatic Links}
 			\centering\pic[width=0.5\textwidth]{example-image} % omit file extension of the image picture
 		\end{example}
-		\begin{note}{Explanation}
+		\begin{info}{Explanation}
 			In order to automatically add a (source) link to the picture, the link simply has to be stored in a txt-file with the same filename.
-		\end{note}
+		\end{info}
 	\end{fancycolumns}
 \end{frame}
 
 \subsection{Automatic Dark-Mode for Pictures}
 \begin{frame}{\insertsubsection}
 	\begin{fancycolumns}
-		\begin{notetight}{Normal Image with \texttt{\textbackslash pic}}
+		\begin{infotight}{Normal Image with \texttt{\textbackslash pic}}
 			\centering
 			\pic[width=.7\textwidth]{example-image}
-		\end{notetight}
+		\end{infotight}
 	\nextcolumn
-		\begin{notetight}{Inverted Image with \texttt{\textbackslash picDark} (in dark-mode only)}
+		\begin{infotight}{Inverted Image with \texttt{\textbackslash picDark} (in dark-mode only)}
 			\centering
 			\picDark[width=.7\textwidth]{example-image.jpg} % does only work for bitmap images so far
-		\end{notetight}
+		\end{infotight}
 	\end{fancycolumns}
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		Using \texttt{\textbackslash picDark} instead of \texttt{\textbackslash pic}, the dark version of an image that is saved as \texttt{<image-name>-dark} automatically gets used when dark-mode is enabled.
 
 		Images can also automatically be inverted if there is no separate dark version. Therefore, white gets converted to a dark gray that matches the dark background color of the slides.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \section{Slide Layouts}
@@ -204,11 +204,11 @@
 		This is an example text that is shown in the \textbf{last column}.
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		Columns are separated by the command \texttt{\textbackslash nextcolumn}.
 
 		The option \texttt{columns} specifies the number of columns that should be generated. The default number of columns is two.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \subsection{Columns with Custom Width}
@@ -227,11 +227,11 @@
 		\end{example}
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		The widths of the single columns can also be manually specified by a list of percentages given to the option \texttt{widths}.
 
 		All columns whose width is not specified are equally split over the remaining space.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \subsection{Columns with Custom Height}
@@ -240,9 +240,9 @@
 		\begin{example}{}
 			This is the content of the first column.
 		\end{example}
-		\begin{note}{Explanation}
+		\begin{info}{Explanation}
 			If the content of a column exceeds a certain height, the common centering of all columns will not work anymore because beamer does not define the height of a slide. In this case, you can set the height of the columns manually by adding the option \texttt{height=<height>}.
-		\end{note}
+		\end{info}
 	\nextcolumn
 		\begin{example}{}
 			This is the content of the second column. It is too high and would make the first column move downwards without additional options.
@@ -258,29 +258,29 @@
 			This is the content of the first column.
 		\end{example}
 		\begin{fancycolumns}[columns=4]
-			\mynote{}{1.1}
+			\myinfo{}{1.1}
 			\nextcolumn
-			\mynote{}{1.2}
+			\myinfo{}{1.2}
 			\nextcolumn
-			\mynote{}{1.3}
+			\myinfo{}{1.3}
 			\nextcolumn
-			\mynote{}{1.4}
+			\myinfo{}{1.4}
 		\end{fancycolumns}
 	\nextcolumn
 		\begin{example}{}
 			A column on the right side
 		\end{example}
 		\begin{fancycolumns}[T]
-			\mynote{}{2.1}
+			\myinfo{}{2.1}
 			\begin{fancycolumns}[columns=3]
-				\mynote{}{2.1.1}
+				\myinfo{}{2.1.1}
 				\nextcolumn
-				\mynote{}{2.1.2}
+				\myinfo{}{2.1.2}
 				\nextcolumn
-				\mynote{}{2.1.3}
+				\myinfo{}{2.1.3}
 			\end{fancycolumns}
 			\nextcolumn
-			\mynote{}{2.2}
+			\myinfo{}{2.2}
 		\end{fancycolumns}
 	\end{fancycolumns}
 \end{frame}
@@ -295,13 +295,13 @@
 		This is an example text that is shown in the \textbf{third column}.
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		The option \texttt{keep} (short for \texttt{animation=keep}) introduces an animation which lets the columns appear one after another.
 
 		The previous columns are kept on the slide when a new column is displayed.
 
 		Animations are ignored in handout mode.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \begin{frame}{\insertsubsection\ -- Option forget}
@@ -313,13 +313,13 @@
 		This is an example text that is shown in the \textbf{third column}.
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		The option \texttt{forget} (short for \texttt{animation=forget}) introduces an animation which lets the columns appear one after another.
 
 		The previous columns are removed when a new column is displayed.
 
 		Animations are ignored in handout mode.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \begin{frame}{\insertsubsection\ -- Option animation=none}
@@ -331,11 +331,11 @@
 		This is an example text that is shown in the \textbf{third column}.
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		The option \texttt{animation=none} deactivates the animation of the columns.
 
 		In the template, this is the default. However, you can overwrite the defaults to animate all slides easily (see \texttt{setfancycolumnsdefault} in the source code). Then, it might be necessary to deactivate those animations for some slides.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \begin{frame}[label=current]{\insertsubsection\ -- Option reverse}
@@ -347,22 +347,22 @@
 		This is an example text that is shown in the \textbf{third column}.
 	\end{fancycolumns}
 	\vfill
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		The option \texttt{reverse} inverts the order of any animation that is specified (i.e., using \texttt{keep} or \texttt{forget}).
-	\end{note}
+	\end{info}
 \end{frame}
 
 \section{Other Features}
 
 \subsection{Auto-Scaling for Long Titles}
 \begin{frame}{\insertsubsection\ -- Long Titles are Scaled Down to the Available Space}
-	\begin{note}{Explanation}
+	\begin{info}{Explanation}
 		Very long frame titles are scaled down automatically.
 
 		\hfill\hfill\hfill This can avoid annoying linebreaks for a single character or word.\hfill~
 
 		\hfill Use with care.
-	\end{note}
+	\end{info}
 \end{frame}
 
 \subsection{Easy Navigation in Slides}

--- a/fancybeamer.sty
+++ b/fancybeamer.sty
@@ -690,9 +690,9 @@
 % => \myexample and \myexampletight
 % furthermore defines the environment \begin{example}{<title>} ... \end{example}
 \fancy@DeclareBox{example}{blue}
-% => \mynote and \mynotetight
-% furthermore defines the environment \begin{note}{<title>} ... \end{note}
-\fancy@DeclareBox{note}{red}
+% => \myinfo and \myinfotight
+% furthermore defines the environment \begin{info}{<title>} ... \end{info}
+\fancy@DeclareBox{info}{red}
 
 % ---------------------------------------------
 % Pictures


### PR DESCRIPTION
Currently, the note command of Beamer is broken because of a template-defined colorbox (see #24). This PR addresses this problem by renaming the box to "info".

This PR resolves issue #24 